### PR TITLE
add test for azure managed identity and use a normal az login flow

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -12,8 +12,7 @@ jobs:
   azure-admin-credentials:
     name: "Azure Container Registry - admin credentials"
     runs-on: ubuntu-latest
-    
-      
+
     steps:
       - uses: actions/checkout@v3
 
@@ -76,21 +75,44 @@ jobs:
 
       - uses: azure/CLI@v1
         with:
+          # login to the ACR using the login we just did above.
+          # this will perform a 'docker login' with the identity-token-based credential from that Azure identity
           inlineScript: |
-            echo "DOCKER_TOKEN=$(az acr login --name sdkcontainerdemo --expose-token --output tsv --query accessToken)" >> $GITHUB_ENV
-
-      - name: Log in to container registry
-        uses: azure/docker-login@v1
-        with:
-          login-server: sdkcontainerdemo.azurecr.io
-          username: 00000000-0000-0000-0000-000000000000
-          password: ${{ env.DOCKER_TOKEN }}
+            az acr login --name sdkcontainerdemo
 
       - uses: ./.github/actions/publishAndLog
         with:
           profile: azure
           variant: ad-credential
-  
+
+  azure-managed-identity:
+    name: Azure Container Registry - Managed Identity
+    runs-on: ubuntu-latest
+
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v2
+
+      - uses: Azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_MANAGED_IDENTITY_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: azure/CLI@v1
+        with:
+          # login to the ACR using the login we just did above.
+          # this will perform a 'docker login' with the identity-token-based credential from that Azure identity
+          inlineScript: |
+            az acr login --name sdkcontainerdemo
+
+      - uses: ./.github/actions/publishAndLog
+        with:
+          profile: azure
+          variant: azure-managed-identity
 
   github:
     name: GitHub Package Registry
@@ -244,7 +266,7 @@ jobs:
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v2
-      
+
       - uses: ./.github/actions/publishAndLog
         with:
           profile: localdocker
@@ -343,7 +365,7 @@ jobs:
           context: .
           tags: chusk3/net-sdk-container-demo:dockerfile
           file: ./Dockerfile-sc
-      
+
       - name: publish framework-dependent
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -98,9 +98,7 @@ jobs:
 
       - uses: Azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_MANAGED_IDENTITY_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          creds: '{"clientId":"${{ secrets.AZURE_MANAGED_IDENTITY_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_MANAGED_IDENTITY_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
       - uses: azure/CLI@v1
         with:

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -67,18 +67,27 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v2
 
-      - uses: Azure/login@v1
+      - name: login to Azure using AD credentials
+        uses: Azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: azure/CLI@v1
+      - name: get ACR access token
+        uses: azure/CLI@v1
         with:
           # login to the ACR using the login we just did above.
           # this will perform a 'docker login' with the identity-token-based credential from that Azure identity
           inlineScript: |
-            az acr login --name sdkcontainerdemo
+            echo "DOCKER_TOKEN=$(az acr login --name sdkcontainerdemo --expose-token --output tsv --query accessToken)" >> $GITHUB_ENV
+
+      - name: Log in to container registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: sdkcontainerdemo.azurecr.io
+          username: "00000000-0000-0000-0000-000000000000"
+          password: ${{ env.DOCKER_TOKEN }}
 
       - uses: ./.github/actions/publishAndLog
         with:
@@ -96,16 +105,25 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v2
 
-      - uses: Azure/login@v1
+      - name: login to azure with managed identity
+        uses: Azure/login@v1
         with:
           creds: '{"clientId":"${{ secrets.AZURE_MANAGED_IDENTITY_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_MANAGED_IDENTITY_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
 
-      - uses: azure/CLI@v1
+      - name: get ACR access token
+        uses: azure/CLI@v1
         with:
           # login to the ACR using the login we just did above.
           # this will perform a 'docker login' with the identity-token-based credential from that Azure identity
           inlineScript: |
-            az acr login --name sdkcontainerdemo
+            echo "DOCKER_TOKEN=$(az acr login --name sdkcontainerdemo --expose-token --output tsv --query accessToken)" >> $GITHUB_ENV
+
+      - name: Log in to container registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: sdkcontainerdemo.azurecr.io
+          username: "00000000-0000-0000-0000-000000000000"
+          password: ${{ env.DOCKER_TOKEN }}
 
       - uses: ./.github/actions/publishAndLog
         with:

--- a/sdk-container-demo.csproj
+++ b/sdk-container-demo.csproj
@@ -20,11 +20,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dotnet.ReproducibleBuilds" Version="1.1.1">
-      <IncludeAssets>build; buildtransitive</IncludeAssets>
-      <PrivateAssets>build; buildtransitive</PrivateAssets>
-      <ExcludeAssets>runtime;</ExcludeAssets>
-    </PackageReference>
    <PackageReference Include="Microsoft.Net.Build.Containers" Version="$(SdkContainerSupportPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This uses normal `az` cli logins (like customers would do) to test both the 'normal end user' auth flow and the 'managed identity' auth flow, both of which should hit the IdentityToken-based authentication method that is in the package that we have checked in currently.
 